### PR TITLE
Do not build all targets of soil simulator

### DIFF
--- a/plugin/soil/CMakeLists.txt
+++ b/plugin/soil/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_options(
   ${EXTRA_LINK_OPTIONS}
 )
 
-add_subdirectory(soil_dynamics_cpp)
+add_subdirectory(soil_dynamics_cpp EXCLUDE_FROM_ALL)


### PR DESCRIPTION
# Description
- Added an option in CMake files to not build all targets of soil simulator