### PR TITLE
Set version number for the soil simulator

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -10,7 +10,7 @@ cd $SCRIPT_DIR
 if [ ! -d "plugin/soil/soil_dynamics_cpp" ]; then
   echo "Cloning soil_dynamics_cpp..."
   cd plugin/soil/
-  git clone https://github.com/KennyVilella/soil_dynamics_cpp
+  git clone -b v1.0.0 https://github.com/KennyVilella/soil_dynamics_cpp
   cd $SCRIPT_DIR
 else
   cd plugin/soil/soil_dynamics_cpp
@@ -20,7 +20,7 @@ else
     echo "Cloning soil_dynamics_cpp..."
     cd ../
     rm -rf soil_dynamics_cpp
-    git clone https://github.com/KennyVilella/soil_dynamics_cpp
+    git clone -b v1.0.0 https://github.com/KennyVilella/soil_dynamics_cpp
   fi
   cd $SCRIPT_DIR
 fi


### PR DESCRIPTION
# Description
- Set the version number for the soil simulator in the building script. This is to avoid breaking the simulator between two release.